### PR TITLE
File saving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,6 +755,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,6 +821,12 @@ name = "dpi"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ecolor"
@@ -861,6 +888,19 @@ dependencies = [
  "log",
  "nohash-hasher",
  "profiling",
+]
+
+[[package]]
+name = "egui-file-dialog"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee10521c25a2fd1ef0d9568ef181087c7648165d61aa7e82f879f408d4c3b4e"
+dependencies = [
+ "directories",
+ "dunce",
+ "egui",
+ "serde",
+ "sysinfo",
 ]
 
 [[package]]
@@ -2085,6 +2125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "orbclient"
 version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2375,6 +2421,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox",
+ "thiserror 2.0.11",
+]
+
+[[package]]
 name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2399,6 +2456,7 @@ dependencies = [
  "byteorder",
  "eframe",
  "egui",
+ "egui-file-dialog",
  "enum_dispatch",
  "lazy_static",
  "ron",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,6 +764,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2454,6 +2463,7 @@ name = "rs_class"
 version = "0.1.0-alpha"
 dependencies = [
  "byteorder",
+ "dirs",
  "eframe",
  "egui",
  "egui-file-dialog",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ enum_dispatch = "0.3.13"
 ron = "0.8.1"
 lazy_static = "1.5.0"
 egui-file-dialog = "0.9.0"
+dirs = "6.0.0"
 [dependencies.windows-sys] 
 version = "0.59.0"
 features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ sysinfo = "0.33.1"
 enum_dispatch = "0.3.13"
 ron = "0.8.1"
 lazy_static = "1.5.0"
+egui-file-dialog = "0.9.0"
 [dependencies.windows-sys] 
 version = "0.59.0"
 features = [

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
 
 #[derive(Default)]
 struct MyEguiApp {
-    root_element: StructDataType,
+    struct_tabs: Vec<StructDataType>,
     system: System,
     selected_process: Option<Process>,
     state: State,
@@ -51,11 +51,6 @@ impl MyEguiApp {
     fn new(_cc: &eframe::CreationContext<'_>) -> Self {
         let mut s = Self::default();
         let health = IntegerDataType::default();
-        let e = StructEntry::new("Health".into(), health.into());
-        s.root_element.push_entry(e);
-        
-        // Dirty by default, because it is considered as a new project.
-        s.is_dirty = true;
 
         let system = System::new_with_specifics(RefreshKind::nothing().with_processes(ProcessRefreshKind::everything()));
         println!("Got {} processes.", system.processes().len());
@@ -68,13 +63,13 @@ impl MyEguiApp {
 
     fn save_to_file(&self) -> Result<(), String> {
         let file = std::fs::File::create(self.save_file_location.as_ref().ok_or("please select a save location")?).map_err(|e| e.to_string())?;
-        ron::ser::to_writer_pretty(file, &self.root_element, ron::ser::PrettyConfig::default())
+        ron::ser::to_writer_pretty(file, &self.struct_tabs, ron::ser::PrettyConfig::default())
             .map_err(|e| e.to_string())
     }
 
     fn load_from_file(&mut self) -> Result<(), String> {
         let file = std::fs::File::open(self.save_file_location.as_ref().ok_or("No file path for load available")?).map_err(|e| e.to_string())?;
-        self.root_element = ron::de::from_reader(file).map_err(|e| e.to_string())?;
+        self.struct_tabs = ron::de::from_reader(file).map_err(|e| e.to_string())?;
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use egui::{Frame, Style};
 use serde::{Deserialize, Serialize};
 use sysinfo::{System, RefreshKind, ProcessRefreshKind};
 use std::ops::DerefMut;
-use std::path::{Display, PathBuf};
+use std::path::{PathBuf, Path};
 use std::sync::{Arc, Mutex};
 
 use rs_class::{typing::*, ops::*};
@@ -23,21 +23,30 @@ struct MyEguiApp {
     root_element: StructDataType,
     system: System,
     selected_process: Option<Process>,
+    state: State,
 
     // dialogs
     process_dialog: Option<ProcessDialog>,
+    closing_dialog: bool,
+    save_file_dialog: egui_file_dialog::FileDialog,
     
     // file saving
     save_file_location: Option<PathBuf>,
-    is_dirty: bool
+    is_dirty: bool,
+}
+
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq)]
+enum State {
+    #[default]
+    Normal,
+    Load,
+    Save,
+    SaveAndQuit,
+    Quit,
 }
 
 impl MyEguiApp {
     fn new(_cc: &eframe::CreationContext<'_>) -> Self {
-        // Customize egui here with cc.egui_ctx.set_fonts and cc.egui_ctx.set_visuals.
-        // Restore app state using cc.storage (requires the "persistence" feature).
-        // Use the cc.gl (a glow::Context) to create graphics shaders and buffers that you can use
-        // for e.g. egui::PaintCallback.
         let mut s = Self::default();
         let health = IntegerDataType::default();
         let e = StructEntry::new("Health".into(), health.into());
@@ -51,10 +60,88 @@ impl MyEguiApp {
         s.system = system;
         s
     }
+
+    fn save_to_file(&self) -> Result<(), String> {
+        let file = std::fs::File::create(self.save_file_location.as_ref().ok_or("please select a save location")?).map_err(|e| e.to_string())?;
+        let r = ron::ser::to_writer_pretty(file, &self.root_element, ron::ser::PrettyConfig::default())
+            .map_err(|e| e.to_string());
+        r
+    }
+
+    fn quit(&mut self, ctx: &egui::Context) {
+        self.state = State::Quit;
+        ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+    }
 }
 
 impl eframe::App for MyEguiApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        // Check for closing
+        let close_requested = ctx.input(|i| i.viewport().close_requested());
+        if close_requested && self.state != State::Quit &&self.is_dirty {
+            self.closing_dialog = true;
+            ctx.send_viewport_cmd(egui::ViewportCommand::CancelClose);
+        }
+        if self.closing_dialog {
+            egui::Modal::new("close_unsaved_dialog".into()).show(ctx, 
+            |ui| {
+                ui.heading("You have unsaved changes");
+                ui.horizontal(|ui| {
+                    if ui.button("Quit w/o saving").clicked() {
+                        self.closing_dialog = false;
+                        self.quit(ctx);
+                    }
+                    if ui.button("Save & Quit").clicked() {
+                        self.state = State::SaveAndQuit;
+                        self.closing_dialog = false;
+                    }
+                    if ui.button("Cancel").clicked() {
+                        self.closing_dialog = false;
+                    }
+                })
+            });
+        }
+
+        self.save_file_dialog.update(ctx);
+
+        // Handle save requests
+        if self.state == State::SaveAndQuit || self.state == State::Save {
+            //Are the changes saved ?
+            if self.is_dirty {
+                if self.save_file_location.is_some() {
+                    match MyEguiApp::save_to_file(self) {
+                        Ok(()) => {
+                            self.is_dirty = false;
+                            if self.state == State::SaveAndQuit {
+                                self.quit(ctx);
+                            }
+                        }
+                        Err(e) => {
+                            println!("ERROR: could not save: {}",e);
+                            self.state = State::Normal;
+                        }
+                    }
+                } else {
+                    if self.save_file_dialog.state() == egui_file_dialog::DialogState::Closed {
+                        self.save_file_dialog
+                            .save_file();
+                    }
+
+                    self.save_file_location = self.save_file_dialog.take_picked().map(|p| p.to_path_buf());
+                    if self.save_file_dialog.state() == egui_file_dialog::DialogState::Cancelled {
+                        println!("User did not choose save file, saving is cancelled");
+                        self.state = State::Normal;
+                    }
+                }
+            } else {
+                if self.state == State::SaveAndQuit {
+                    self.quit(ctx);
+                } else {
+                    self.state = State::Normal;
+                }
+            }
+        }
+
         // Process Selection Window
         if let Some(pd) = self.process_dialog.as_mut() {
             pd.show(ctx);
@@ -76,26 +163,20 @@ impl eframe::App for MyEguiApp {
                     dialog.open();
                     self.process_dialog = Some(dialog);
                 };
-                if ui.button("load").clicked() {};
-                if ui.button("save").clicked() {
-                    let mut file_location = PathBuf::from(".");
-                    file_location.push("tmp_save.ron");
-                    println!("{:?}", file_location.canonicalize());
-                    if let Ok(f) = std::fs::File::create(file_location) {
-                        let r = ron::ser::to_writer_pretty(f, &self.root_element, ron::ser::PrettyConfig::default());
-                        let m = match r {
-                            Ok(_) => "File has been saved!".into(),
-                            Err(e) => format!("Could not serialize element: {}", e)
-                        };
-                        println!("{}",m);
-                    } else {
-                        println!("Could not open file");
-                    }
+                if ui.button("load").clicked() {
+                    self.state = State::Load;
+                };
+                let save_button = egui::Button::new("save");
+                if ui.add_enabled(self.is_dirty, save_button).clicked() {
+                    self.state = State::Save;
                 };
             });
         });
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("Hello World!");
+            ui.label(format!("App state: {:?}", self.state));
+            ui.label(format!("Dirty? {}", self.is_dirty));
+            ui.label(format!("File location: {:?}", self.save_file_location));
             ui.label(format!("Selected process: {}", self.selected_process.as_ref().and_then(|p| self.system.process(p.pid())).and_then(|p| p.name().to_str()).unwrap_or("None")));
             let pstatus = self.process_dialog.as_ref().map(|pd| pd.state());
             ui.label(format!("Process window status: {:?}", pstatus));

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,9 +66,8 @@ impl MyEguiApp {
 
     fn save_to_file(&self) -> Result<(), String> {
         let file = std::fs::File::create(self.save_file_location.as_ref().ok_or("please select a save location")?).map_err(|e| e.to_string())?;
-        let r = ron::ser::to_writer_pretty(file, &self.root_element, ron::ser::PrettyConfig::default())
-            .map_err(|e| e.to_string());
-        r
+        ron::ser::to_writer_pretty(file, &self.root_element, ron::ser::PrettyConfig::default())
+            .map_err(|e| e.to_string())
     }
 
     fn quit(&mut self, ctx: &egui::Context) {
@@ -156,7 +155,7 @@ impl eframe::App for MyEguiApp {
                                 .as_ref()
                                 .and_then(|p| self.system.process(p.pid()))
                                 .and_then(|p| p.name().to_str())
-                                .and_then(|s| PathBuf::try_from(s).ok())
+                                .map(|s| PathBuf::from(s))
                                 .and_then(|path| path.with_extension("rsclass").to_str().map(ToOwned::to_owned))
                                 .unwrap_or("new_project.rsclass".into());
 


### PR DESCRIPTION
Added saving/loading to/from a file capabilities to the main GUI application.

This entails the follwing:

- Track the location of the save file, and open a file dialog to select it when needed.
- Open a file dialog to load the saved data from a file.
- Keep track of the status of the edits, and ask to save before any data loss-inducing action (ie. quitting and loading).