### PR TITLE
Tie dialogs to states of the program

### DIFF
--- a/src/gui/load_dialog.rs
+++ b/src/gui/load_dialog.rs
@@ -1,0 +1,72 @@
+use std::{path::PathBuf, sync::Arc};
+
+use rs_class::ops::SystemProcess;
+
+pub type State = super::DialogState<PathBuf>;
+
+#[derive(Debug)]
+pub struct LoadDialog {
+    state: State,
+    file_dialog: egui_file_dialog::FileDialog,
+}
+
+impl LoadDialog {
+    pub fn new(app: &crate::MyEguiApp) -> Self {
+        let mut fd: egui_file_dialog::FileDialog = egui_file_dialog::FileDialog::new()
+            .add_file_filter("rsclass", Arc::new(|path| path.extension().map(|ext| ext == "rsclass").unwrap_or_default()))
+            .default_file_filter("rsclass");
+        
+        if let Some(s) = app
+            .selected_process
+            .as_ref()
+            .and_then(|p| app.system.process(p.pid()))
+            .and_then(|p| p.name().to_str())
+            .map(|s| PathBuf::from(s))
+            .and_then(|path| path.with_extension("rsclass").to_str().map(ToOwned::to_owned))
+        {
+            fd.config_mut().default_file_name = s;
+        }
+
+        if let Some(p) = dirs::document_dir() {
+            fd.config_mut().initial_directory = p;
+        }
+
+        fd.pick_file();
+
+        Self {
+            state: Default::default(),
+            file_dialog: fd,
+        }
+    }
+}
+
+impl super::Dialog<PathBuf> for LoadDialog{
+    fn show(&mut self, ctx: &egui::Context) {
+        self.file_dialog.update(ctx);
+        use egui_file_dialog::DialogState::*;
+        match self.file_dialog.state() {
+            Open => {},
+            Picked(p) => self.state = State::Selected(p.clone()),
+            Cancelled => {
+                self.state = State::Cancelled;
+                println!("User did not choose save file, saving is cancelled");
+            },
+            _ => unreachable!(),
+        }
+    }
+
+    fn cancel(&mut self) {
+        self.state = State::Cancelled;
+    }
+
+    fn get_data(&self) -> Option<&PathBuf> {
+        if let State::Selected(c) = &self.state {
+            Some(c)
+        } else {
+            None
+        }
+    }
+    fn state(&self) -> &super::DialogState<PathBuf> {
+        &self.state
+    }
+}

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1,5 +1,6 @@
 pub mod process_dialog;
 pub mod type_selection_dialog;
+pub mod prompt_save_dialog;
 
 #[derive(Copy, Debug, Clone, Eq, PartialEq)]
 pub enum DialogState<T> where T: Clone {

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -4,21 +4,13 @@ pub mod type_selection_dialog;
 #[derive(Copy, Debug, Clone, Eq, PartialEq)]
 pub enum DialogState<T> where T: Clone {
     Open,       // Visible
-    Closed,     // Destroyed
     Selected(T),// Selected
     Cancelled   // Cancelled
 }
 
-pub trait SelectDialog {
-    type SelectionType: Clone;
-
-    fn state(&self) -> &DialogState<Self::SelectionType>;
+pub trait Dialog<T: Clone>{
+    fn state(&self) -> &DialogState<T>;
     fn show(&mut self, ctx: &egui::Context);
     fn cancel(&mut self);
-    fn get_data(&self) -> Option<Self::SelectionType>;
-}
-
-pub enum Dialog {
-    ProcessSelection(process_dialog::ProcessDialog),
-    TypeSelection(type_selection_dialog::TypeSelectionDialog),
+    fn get_data(&self) -> Option<&T>;
 }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1,6 +1,9 @@
 pub mod process_dialog;
 pub mod type_selection_dialog;
 pub mod prompt_save_dialog;
+pub mod save_dialog;
+pub mod load_dialog;
+
 
 #[derive(Copy, Debug, Clone, Eq, PartialEq, Default)]
 pub enum DialogState<T> where T: Clone {

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -2,8 +2,9 @@ pub mod process_dialog;
 pub mod type_selection_dialog;
 pub mod prompt_save_dialog;
 
-#[derive(Copy, Debug, Clone, Eq, PartialEq)]
+#[derive(Copy, Debug, Clone, Eq, PartialEq, Default)]
 pub enum DialogState<T> where T: Clone {
+    #[default]
     Open,       // Visible
     Selected(T),// Selected
     Cancelled   // Cancelled

--- a/src/gui/prompt_save_dialog.rs
+++ b/src/gui/prompt_save_dialog.rs
@@ -3,7 +3,7 @@ pub enum Choice {
     Save,
     Discard
 }
-type State = super::DialogState<Choice>;
+pub type State = super::DialogState<Choice>;
 
 #[derive(Debug, Default)]
 pub struct PromptSaveDialog {

--- a/src/gui/prompt_save_dialog.rs
+++ b/src/gui/prompt_save_dialog.rs
@@ -1,0 +1,55 @@
+use crate::MyEguiApp;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum Choice {
+    Save,
+    Discard
+}
+type State = super::DialogState<Choice>;
+
+#[derive(Debug)]
+pub struct PromptSaveDialog {
+    state: State,
+}
+
+impl Default for PromptSaveDialog {
+    fn default() -> Self {
+        Self {
+            state: State::Open,
+        }
+    }
+}
+
+impl super::Dialog<Choice> for PromptSaveDialog {
+    fn show(&mut self, ctx: &egui::Context) {
+        egui::Modal::new("close_unsaved_dialog".into()).show(ctx, |ui| {
+            ui.heading("Do you wish to save your changes ?");
+            ui.horizontal(|ui| {
+                if ui.button("Discard changes").clicked() {
+                    self.state = State::Selected(Choice::Discard);
+                }
+                else if ui.button("Save changes").clicked() {
+                    self.state = State::Selected(Choice::Save);
+                }
+                else if ui.button("Cancel").clicked() {
+                    self.state = State::Cancelled;
+                }
+            })
+        });
+    }
+
+    fn cancel(&mut self) {
+        self.state = State::Cancelled;
+    }
+
+    fn get_data(&self) -> Option<&Choice> {
+        if let State::Selected(c) = &self.state {
+            Some(c)
+        } else {
+            None
+        }
+    }
+    fn state(&self) -> &super::DialogState<Choice> {
+        &self.state
+    }
+}

--- a/src/gui/prompt_save_dialog.rs
+++ b/src/gui/prompt_save_dialog.rs
@@ -1,5 +1,3 @@
-use crate::MyEguiApp;
-
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum Choice {
     Save,
@@ -7,17 +5,9 @@ pub enum Choice {
 }
 type State = super::DialogState<Choice>;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct PromptSaveDialog {
     state: State,
-}
-
-impl Default for PromptSaveDialog {
-    fn default() -> Self {
-        Self {
-            state: State::Open,
-        }
-    }
 }
 
 impl super::Dialog<Choice> for PromptSaveDialog {

--- a/src/gui/save_dialog.rs
+++ b/src/gui/save_dialog.rs
@@ -1,0 +1,71 @@
+use std::{path::PathBuf, sync::Arc};
+
+use rs_class::ops::SystemProcess;
+
+pub type State = super::DialogState<PathBuf>;
+
+#[derive(Debug)]
+pub struct SaveDialog  {
+    state: State,
+    file_dialog: egui_file_dialog::FileDialog,
+}
+
+impl SaveDialog  {
+    pub fn new(app: &crate::MyEguiApp) -> Self {
+        let mut fd: egui_file_dialog::FileDialog = egui_file_dialog::FileDialog::new()
+            .add_file_filter("rsclass", Arc::new(|path| path.extension().map(|ext| ext == "rsclass").unwrap_or_default()))
+            .default_file_filter("rsclass");
+        if let Some(s) = app
+            .selected_process
+            .as_ref()
+            .and_then(|p| app.system.process(p.pid()))
+            .and_then(|p| p.name().to_str())
+            .map(|s| PathBuf::from(s))
+            .and_then(|path| path.with_extension("rsclass").to_str().map(ToOwned::to_owned))
+        {
+            fd.config_mut().default_file_name = s;
+        }
+
+        if let Some(p) = dirs::document_dir() {
+            fd.config_mut().initial_directory = p;
+        }
+
+        fd.save_file();
+
+        Self {
+            state: Default::default(),
+            file_dialog: fd,
+        }
+    }
+}
+
+impl super::Dialog<PathBuf> for SaveDialog {
+    fn show(&mut self, ctx: &egui::Context) {
+        self.file_dialog.update(ctx);
+        use egui_file_dialog::DialogState::*;
+        match self.file_dialog.state() {
+            Open => {},
+            Picked(p) => self.state = State::Selected(p.clone()),
+            Cancelled => {
+                println!("User did not choose save file, saving is cancelled");
+                self.state = State::Cancelled
+            },
+            _ => unreachable!(),
+        }
+    }
+
+    fn cancel(&mut self) {
+        self.state = State::Cancelled;
+    }
+
+    fn get_data(&self) -> Option<&PathBuf> {
+        if let State::Selected(c) = &self.state {
+            Some(c)
+        } else {
+            None
+        }
+    }
+    fn state(&self) -> &super::DialogState<PathBuf> {
+        &self.state
+    }
+}

--- a/src/gui/type_selection_dialog.rs
+++ b/src/gui/type_selection_dialog.rs
@@ -57,7 +57,7 @@ impl TypeSelectionDialog {
                     self.state = State::Cancelled;
                 }
             },
-            _ => {self.state = State::Closed},
+            _ => {},
         };
 
         self


### PR DESCRIPTION
This change will tie the state of the program to the dialog it should display.

This reflects the mutual exclusion of all the dialogs in the program, and tidies up the data by getting rid of all the Option<Dialog>.

The following states are thus introduced:

- **Normal** : Default state of the program
- **ProcessSelection** : Prompts the to select a process.
- **TypeSelection** : Prompt the user to select a type.
- **PromptForSave** : When the user tries to do a data loss-inducing action, a prompt to save or discard the data is presented.
- **Save** : Tries to save, with a dialog to select a file in case the save file location is still undefined.
- **Load** : Prompt the user to select a save file to load.
- **Quit** : Exits the program.